### PR TITLE
[Breaking Changes] Improve request

### DIFF
--- a/Sources/JNetworking/WebServices/JNBodyRequest.swift
+++ b/Sources/JNetworking/WebServices/JNBodyRequest.swift
@@ -1,0 +1,31 @@
+//
+//  JNBodyRequest.swift
+//  
+//
+//  Created by Josue Hernandez on 02-07-22.
+//
+
+import Foundation
+
+public class JNBodyRequest<T: Encodable>: JNRequest {
+    private let keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy
+
+    public init(url: URL, method: HTTPMethodType = .get, body: T, headers: Headers = [:], keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .useDefaultKeys) {
+        self.body = body
+        self.keyEncodingStrategy = keyEncodingStrategy
+        super.init(url: url, method: method, headers: headers)
+    }
+
+    // MARK: Internal
+
+    override func addToRequest(_ request: inout URLRequest) {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = keyEncodingStrategy
+        request.httpBody = try? encoder.encode(body)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    }
+
+    // MARK: Private
+
+    private let body: T
+}

--- a/Sources/JNetworking/WebServices/JNEmpty.swift
+++ b/Sources/JNetworking/WebServices/JNEmpty.swift
@@ -1,0 +1,10 @@
+//
+//  JNEmpty.swift
+//  
+//
+//  Created by Josue Hernandez on 02-07-22.
+//
+
+import Foundation
+
+public struct JNEmpty: Decodable, LocalizedError, Equatable {}

--- a/Sources/JNetworking/WebServices/JNNetworkError.swift
+++ b/Sources/JNetworking/WebServices/JNNetworkError.swift
@@ -1,0 +1,44 @@
+//
+//  JNNetworkError.swift
+//  
+//
+//  Created by Josue Hernandez on 02-07-22.
+//
+
+import Foundation
+
+public enum JNNetworkError<T: LocalizedError>: LocalizedError {
+    case failedRequest(URLError?)
+    case invalidRequest(T)
+    case invalidResponse(Int)
+    case responseTypeMismatch
+    
+    public var errorDescription: String? {
+        switch self {
+            case .failedRequest:
+                return "The request failed."
+            case let .invalidRequest(error):
+                return error.localizedDescription
+            case let .invalidResponse(statusCode):
+                return "The response was invalid (\(statusCode))."
+            case .responseTypeMismatch:
+                return "The response did not match the expected type."
+        }
+    }
+
+    public var failureReason: String? {
+        switch self {
+            case let .failedRequest(error):
+                return error?.localizedDescription
+            case let .invalidRequest(error):
+                return error.localizedDescription
+            case let .invalidResponse(statusCode):
+                return "The server returned a \(statusCode) status code."
+            case .responseTypeMismatch:
+                return "The response did not match the expected error type."
+        }
+    }
+    
+}
+
+extension JNNetworkError: Equatable where T: Equatable {}

--- a/Sources/JNetworking/WebServices/JNRequest.swift
+++ b/Sources/JNetworking/WebServices/JNRequest.swift
@@ -1,0 +1,36 @@
+//
+//  JNRequest.swift
+//  
+//
+//  Created by Josue Hernandez on 02-07-22.
+//
+
+import Foundation
+
+public class JNRequest {
+    public typealias Headers = [String: String]
+
+    public init(url: URL, method: HTTPMethodType = .get, headers: Headers = [:]) {
+        self.url = url
+        self.method = method
+        self.headers = headers
+    }
+
+    // MARK: Internal
+
+    var asURLRequest: URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = method.rawValue
+        request.allHTTPHeaderFields = headers
+        addToRequest(&request)
+        return request
+    }
+
+    func addToRequest(_ request: inout URLRequest) {}
+
+    // MARK: Private
+
+    private let headers: Headers
+    private let method: HTTPMethodType
+    private let url: URL
+}

--- a/Sources/JNetworking/WebServices/JNResponse.swift
+++ b/Sources/JNetworking/WebServices/JNResponse.swift
@@ -1,0 +1,13 @@
+//
+//  JNResponse.swift
+//  
+//
+//  Created by Josue Hernandez on 01-07-22.
+//
+
+import Foundation
+
+public struct JNResponse<T> {
+    public let headers: [AnyHashable: Any]
+    public let value: T
+}

--- a/Sources/JNetworking/WebServices/JNWebClient.swift
+++ b/Sources/JNetworking/WebServices/JNWebClient.swift
@@ -8,14 +8,26 @@
 import Foundation
 
 
+/// This is the struct to implement the request
 public struct JNWebClient {
     
+    /// client a session
     private let requestLoader: RequestLoader
     
+    
+    /// Init method to inject any implementation of the RequestLoader protocol
+    /// - Parameter requestLoader: This is the conforming RequestLoader protocol cobject as the default parameter will instantiate an URLSession
     public init(requestLoader: RequestLoader = URLSession.shared) {
         self.requestLoader = requestLoader
     }
     
+    /// Performs a API request which is called by any service request class.
+    /// It also performs an additional task of validating the auth token and refreshing if necessary
+    ///
+    /// - Parameters:
+    ///   - apiModel: APIModelType which contains the info about api endpath, header & http method type.
+    ///   - completion: Request completion handler.
+    /// - Returns: Returns a URLSessionDataTask instance.
     public func request(apiModel: APIModelType, completion: @escaping JNWebServiceCompletionBlock) -> URLSessionDataTask? {
         return self.requestLoader.requestAPIClient(apiModel: apiModel, completion: completion)
     }

--- a/Sources/JNetworking/WebServices/JNWebClient.swift
+++ b/Sources/JNetworking/WebServices/JNWebClient.swift
@@ -1,0 +1,23 @@
+//
+//  JNWebClient.swift
+//  
+//
+//  Created by Josue Hernandez on 29-06-22.
+//
+
+import Foundation
+
+
+public struct JNWebClient {
+    
+    private let requestLoader: RequestLoader
+    
+    public init(requestLoader: RequestLoader = URLSession.shared) {
+        self.requestLoader = requestLoader
+    }
+    
+    public func request(apiModel: APIModelType, completion: @escaping JNWebServiceCompletionBlock) -> URLSessionDataTask? {
+        return self.requestLoader.requestAPIClient(apiModel: apiModel, completion: completion)
+    }
+    
+}

--- a/Sources/JNetworking/WebServices/JNWebClient.swift
+++ b/Sources/JNetworking/WebServices/JNWebClient.swift
@@ -21,15 +21,24 @@ public struct JNWebClient <T, E> where T: Decodable, E: LocalizedError & Decodab
         self.requestLoader = requestLoader
     }
     
+    
+    /// Performs a API request
+    /// - Parameters:
+    ///   - request:All config to use in a request
+    ///   - completion: Completion handler
+    public func request(request: JNRequest, completion: @escaping JNWebServiceBlock<T, E>) {
+        self.request(request: request.asURLRequest, completion: completion)
+    }
+    
     /// Performs a API request which is called by any service request class.
     /// It also performs an additional task of validating the auth token and refreshing if necessary
     ///
     /// - Parameters:
     ///   - apiModel: APIModelType which contains the info about api endpath, header & http method type.
     ///   - completion: Request completion handler.
-    public func request(apiModel: APIModelType, completion: @escaping JNWebServiceBlock<T, E>) {
+    public func request(request: URLRequest, completion: @escaping JNWebServiceBlock<T, E>) {
         
-        self.requestLoader.requestAPIClient(apiModel: apiModel) { data, response, error in
+        self.requestLoader.requestAPIClient(request: request) { data, response, error in
             if let error = error {
                 completion(.failure(.failedRequest(error)))
             } else if let response = response as? HTTPURLResponse {

--- a/Sources/JNetworking/WebServices/JNWebserviceConfig.swift
+++ b/Sources/JNetworking/WebServices/JNWebserviceConfig.swift
@@ -9,46 +9,10 @@ import Foundation
 
 /// HTTPMethodTypes
 public enum HTTPMethodType: String {
-    case get     = "GET"
-    case post    = "POST"
-    case put     = "PUT"
-}
-
-/// Protocol to which every API should confirm to.
-public protocol APIProtocol {
-    func httpMthodType() -> HTTPMethodType
-    func apiEndPath() -> String
-    func apiBasePath() -> String
-}
-
-/// Request Model type that the APIRequestModel confirms to.
-public protocol APIModelType {
-    var api: APIProtocol { get set }
-    var parameters: [String: Any]? { get set }
-}
-
-/// Request Model that holds every api calls parameters, headers and other api details.
-public struct APIRequestModel: APIModelType {
-    public var api: APIProtocol
-    public var parameters: [String: Any]?
-
-    public init(api: APIProtocol, parameters: [String: Any]? = nil) {
-        self.api = api
-        self.parameters = parameters
-    }
-}
-
-/// Responsible for generating common headers for requests.
-public struct JNWebserviceConfig {
-    /// Generates common headers specific to APIs. Can also accept additional headers if demanded by specific APIs.
-    ///
-    /// - Returns: A configured header JSON dictionary which includes both common and additional params.
-    func generateHeader() -> [String: String] {
-        var headerDict = [String: String]()
-        headerDict["Content-Type"] = "application/json"
-        
-        return headerDict
-    }
-
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case patch = "PATCH"
+    case delete = "DELETE"
 }
 

--- a/Sources/JNetworking/WebServices/JNWebserviceHelper.swift
+++ b/Sources/JNetworking/WebServices/JNWebserviceHelper.swift
@@ -7,24 +7,14 @@
 
 import Foundation
 
-public enum NetworkError<T: LocalizedError>: LocalizedError {
-    case failedRequest(URLError?)
-    case invalidRequest(T)
-    case invalidResponse(Int)
-    case responseTypeMismatch
-}
-
-extension NetworkError: Equatable where T: Equatable {}
-
-public typealias JNWebServiceCompletionBlock = (Result<Data, Error>) -> Void
 public typealias JNWebServiceResult = (Data?, URLResponse?, URLError?) -> Void
-public typealias JNWebServiceBlock<T, E> = (Result<JNResponse<T>, NetworkError<E>>) -> Void
+public typealias JNWebServiceBlock<T, E> = (Result<JNResponse<T>, JNNetworkError<E>>) -> Void
     where T: Decodable, E: LocalizedError & Decodable & Equatable
 
 
 /// Protocol
 public protocol RequestLoader {
-    func requestAPIClient(apiModel: APIModelType, completion: @escaping JNWebServiceResult)
+    func requestAPIClient(request: URLRequest, completion: @escaping JNWebServiceResult)
 }
 
 /// Helper class to prepare request(adding headers & clubbing base URL) & perform API request.
@@ -34,22 +24,9 @@ extension URLSession: RequestLoader {
     /// It also performs an additional task of validating the auth token and refreshing if necessary
     ///
     /// - Parameters:
-    ///   - apiModel: APIModelType which contains the info about api endpath, header & http method type.
+    ///   - request: URLRequest
     ///   - completion: Request completion handler.
-    public func requestAPIClient(apiModel: APIModelType, completion: @escaping JNWebServiceResult) {
-        let escapedAddress = (apiModel.api.apiBasePath() + apiModel.api.apiEndPath()).addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
-
-        var request = URLRequest(url: URL(string: escapedAddress!)!)
-        request.httpMethod = apiModel.api.httpMthodType().rawValue
-        request.allHTTPHeaderFields = JNWebserviceConfig().generateHeader()
-
-        if let params = apiModel.parameters {
-            do {
-                request.httpBody = try JSONSerialization.data(withJSONObject: params as Any, options: .prettyPrinted)
-            } catch let error {
-                print(error.localizedDescription)
-            }
-        }
+    public func requestAPIClient(request: URLRequest, completion: @escaping JNWebServiceResult) {
         dataTask(with: request) { data, response, error in
             completion(data, response, error as? URLError)
         }

--- a/Sources/JNetworking/WebServices/JNWebserviceHelper.swift
+++ b/Sources/JNetworking/WebServices/JNWebserviceHelper.swift
@@ -29,7 +29,7 @@ extension URLSession: RequestLoader {
     public func requestAPIClient(request: URLRequest, completion: @escaping JNWebServiceResult) {
         dataTask(with: request) { data, response, error in
             completion(data, response, error as? URLError)
-        }
+        }.resume()
     }
     
 }

--- a/Sources/JNetworking/WebServices/JNWebserviceHelper.swift
+++ b/Sources/JNetworking/WebServices/JNWebserviceHelper.swift
@@ -15,15 +15,22 @@ enum NetworkError: Error {
 
 public typealias JNWebServiceCompletionBlock = (Result<Data, Error>) -> Void
 
-
+/// Protocol
 public protocol RequestLoader {
     func requestAPIClient(apiModel: APIModelType, completion: @escaping JNWebServiceCompletionBlock) -> URLSessionDataTask?
 }
 
-
+/// Helper class to prepare request(adding headers & clubbing base URL) & perform API request.
 extension URLSession: RequestLoader {
     
-    public func requestAPIClient(apiModel: APIModelType, completion: @escaping JNWebServiceCompletionBlock) -> URLSessionDataTask? {
+    /// Performs a API request which is called by any service request class.
+    /// It also performs an additional task of validating the auth token and refreshing if necessary
+    ///
+    /// - Parameters:
+    ///   - apiModel: APIModelType which contains the info about api endpath, header & http method type.
+    ///   - completion: Request completion handler.
+    /// - Returns: Returns a URLSessionDataTask instance.
+    @discardableResult public func requestAPIClient(apiModel: APIModelType, completion: @escaping JNWebServiceCompletionBlock) -> URLSessionDataTask? {
         let escapedAddress = (apiModel.api.apiBasePath()+apiModel.api.apiEndPath()).addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
         var request = URLRequest(url: URL(string: escapedAddress!)!)
         request.httpMethod = apiModel.api.httpMthodType().rawValue
@@ -66,6 +73,7 @@ public struct JNWebserviceHelper {
     ///   - apiModel: APIModelType which contains the info about api endpath, header & http method type.
     ///   - completion: Request completion handler.
     /// - Returns: Returns a URLSessionDataTask instance.
+    @available(*, deprecated, message: "Use JNWebClient to create a request - This method requestAPI will be deprecated soon")
     @discardableResult public static func requestAPI(apiModel: APIModelType, completion: @escaping JNWebServiceCompletionBlock) -> URLSessionDataTask? {
         let escapedAddress = (apiModel.api.apiBasePath()+apiModel.api.apiEndPath()).addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
         var request = URLRequest(url: URL(string: escapedAddress!)!)

--- a/Sources/JNetworking/WebServices/JNWebserviceHelper.swift
+++ b/Sources/JNetworking/WebServices/JNWebserviceHelper.swift
@@ -73,7 +73,7 @@ public struct JNWebserviceHelper {
     ///   - apiModel: APIModelType which contains the info about api endpath, header & http method type.
     ///   - completion: Request completion handler.
     /// - Returns: Returns a URLSessionDataTask instance.
-    @available(*, deprecated, message: "Use JNWebClient to create a request - This method requestAPI will be deprecated soon")
+    @available(*, deprecated, message: "Use JNWebClient to create a request")
     @discardableResult public static func requestAPI(apiModel: APIModelType, completion: @escaping JNWebServiceCompletionBlock) -> URLSessionDataTask? {
         let escapedAddress = (apiModel.api.apiBasePath()+apiModel.api.apiEndPath()).addingPercentEncoding(withAllowedCharacters: CharacterSet.urlQueryAllowed)
         var request = URLRequest(url: URL(string: escapedAddress!)!)

--- a/Tests/JNetworkingTests/FakeRequestLoader.swift
+++ b/Tests/JNetworkingTests/FakeRequestLoader.swift
@@ -1,0 +1,22 @@
+//
+//  FakeRequestLoader.swift.swift
+//  
+//
+//  Created by Josue Hernandez on 01-07-22.
+//
+
+import Foundation
+import JNetworking
+
+class FakeRequestLoader {
+    
+    private (set) var lastURL: URL?
+    var nextData: Data?
+    var nextResponse: URLResponse?
+    var nextError: URLError?
+    
+    func requestAPIClient(apiModel: APIModelType, completion: @escaping JNWebServiceCompletionBlock) {
+        URLSession.shared.dataTask(with: URL.test)
+    }
+    
+}

--- a/Tests/JNetworkingTests/Helpers/ApiModelHelper.swift
+++ b/Tests/JNetworkingTests/Helpers/ApiModelHelper.swift
@@ -1,0 +1,57 @@
+//
+//  ApiModelHelper.swift
+//  
+//
+//  Created by Josue Hernandez on 01-07-22.
+//
+
+import Foundation
+import JNetworking
+
+
+struct ApiModelHelperConstants {
+    static let baseURL = "https://example.com"
+    static let recipes = "/ios"
+}
+
+struct ApiModelHelperQueyParams {
+
+}
+
+/// This API will hold all API's related to HF
+enum ApiHelper {
+    case getData
+}
+
+extension ApiHelper: APIProtocol {
+
+    func httpMthodType() -> HTTPMethodType {
+        var httpMethodType = HTTPMethodType.get
+        switch self {
+        case .getData:
+            httpMethodType = .get
+        }
+        return httpMethodType
+    }
+
+    func apiEndPath() -> String {
+        var path = ""
+        switch self {
+        case .getData:
+            path += ApiModelHelperConstants.recipes
+        }
+
+        return path
+    }
+
+    func apiBasePath() -> String {
+        switch self {
+        case .getData:
+            return ApiModelHelperConstants.baseURL
+        }
+    }
+
+
+}
+
+

--- a/Tests/JNetworkingTests/Helpers/TestObject.swift
+++ b/Tests/JNetworkingTests/Helpers/TestObject.swift
@@ -1,0 +1,20 @@
+//
+//  TestObject.swift
+//  
+//
+//  Created by Josue Hernandez on 01-07-22.
+//
+
+import Foundation
+
+struct TestObject: Codable, Equatable {
+    let title: String
+
+    init(title: String = "Test Title") {
+        self.title = title
+    }
+}
+
+struct TestError: LocalizedError, Codable, Equatable {
+    let message: String
+}

--- a/Tests/JNetworkingTests/Helpers/URLHelper.swift
+++ b/Tests/JNetworkingTests/Helpers/URLHelper.swift
@@ -1,0 +1,21 @@
+//
+//  URLHelper.swift
+//  
+//
+//  Created by Josue Hernandez on 01-07-22.
+//
+
+import Foundation
+
+extension URL {
+    static var test = Self(string: "https://example.com")!
+}
+
+extension URLRequest {
+    static var test = Self(url: URL.test)
+    static var testWithExtraProperties = Self(
+        url: URL.test,
+        cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
+        timeoutInterval: 42.0
+    )
+}

--- a/Tests/JNetworkingTests/JNetworkingTests.swift
+++ b/Tests/JNetworkingTests/JNetworkingTests.swift
@@ -1,6 +1,10 @@
-import XCTest
+
 @testable import JNetworking
+import XCTest
 
 final class JNetworkingTests: XCTestCase {
+    
+    
+    
     
 }


### PR DESCRIPTION
## Description 
The idea for this change is to make the `URLSession` testable to keep the implementation. 
For this I create a new `Protocol` called `RequestLoader` and create a new struct called `JNWebClient` to give the client session view dependency injection. 


# The new way to implement. 

##  Installation

Add HTTP Client as a dependency through Xcode or directly to Package.swift:

```
.package(url: "https://github.com/jghg02/JNetworking", branch: "master")
```

## Usage

GET request with no expected success or error response object types.

```swift 
import JNetworking

let client = JNWebClient<JNEmpty,JNEmpty>()
let request = JNRequest(url: URL(string: "http://API-URL")!)
client.request(request: request) { result in
    switch result {
    case .success(let data):
      print(data)
    case .failure(let error):
       print(error)
                
    }
}
```
